### PR TITLE
Add Channel for Metric Updates 

### DIFF
--- a/cmd/promquery-poll/main.go
+++ b/cmd/promquery-poll/main.go
@@ -27,7 +27,7 @@ func PollerAction(c *cli.Context) error {
 	p.Init(ctx)
 	ctx1, _ := context.WithTimeout(ctx, time.Duration(c.Int("timeout"))*time.Second)
 
-	_, resultChan := p.Wait(ctx1, time.Duration(c.Int("interval"))*time.Second, time.Duration(c.Int("timeout"))*time.Second)
+	_, resultChan := p.Wait(ctx1, time.Duration(c.Int("interval"))*time.Second)
 	if err := <-resultChan; err != nil {
 		return cli.Exit(fmt.Sprintf("error polling metrics: %s", err.Error()), -1)
 	}

--- a/cmd/promquery-poll/main.go
+++ b/cmd/promquery-poll/main.go
@@ -26,8 +26,9 @@ func PollerAction(c *cli.Context) error {
 
 	p.Init(ctx)
 	ctx1, _ := context.WithTimeout(ctx, time.Duration(c.Int("timeout"))*time.Second)
-	err = <-p.Wait(ctx1, time.Duration(c.Int("interval"))*time.Second)
-	if err != nil {
+
+	_, resultChan := p.Wait(ctx1, time.Duration(c.Int("interval"))*time.Second, time.Duration(c.Int("timeout"))*time.Second)
+	if err := <-resultChan; err != nil {
 		return cli.Exit(fmt.Sprintf("error polling metrics: %s", err.Error()), -1)
 	}
 	return nil

--- a/cmd/promquery-poll/main.go
+++ b/cmd/promquery-poll/main.go
@@ -34,9 +34,10 @@ func PollerAction(c *cli.Context) error {
 			if err != nil {
 				return cli.Exit(fmt.Sprintf("error polling metrics: %s", err.Error()), -1)
 			}
-			break
+			return nil
 		case msg := <-metricsChan:
-			fmt.Printf("Metrics settling, %s.", msg)
+			fmt.Printf("Metrics settling, %s\n", msg)
+		default:
 		}
 	}
 	return nil

--- a/cmd/promquery-poll/main.go
+++ b/cmd/promquery-poll/main.go
@@ -27,9 +27,17 @@ func PollerAction(c *cli.Context) error {
 	p.Init(ctx)
 	ctx1, _ := context.WithTimeout(ctx, time.Duration(c.Int("timeout"))*time.Second)
 
-	_, resultChan := p.Wait(ctx1, time.Duration(c.Int("interval"))*time.Second)
-	if err := <-resultChan; err != nil {
-		return cli.Exit(fmt.Sprintf("error polling metrics: %s", err.Error()), -1)
+	metricsChan, resultChan := p.Wait(ctx1, time.Duration(c.Int("interval"))*time.Second)
+	for {
+		select {
+		case err := <-resultChan:
+			if err != nil {
+				return cli.Exit(fmt.Sprintf("error polling metrics: %s", err.Error()), -1)
+			}
+			break
+		case msg := <-metricsChan:
+			fmt.Printf("Metrics settling, %s.", msg)
+		}
 	}
 	return nil
 }

--- a/poller.go
+++ b/poller.go
@@ -260,6 +260,7 @@ func (p *Poller) Wait(ctx context.Context, interval time.Duration, deadline time
 									successful = 0
 									continue
 								}
+								metricChan <- fmt.Sprintf("initial value %g, current value %g (%s elapsed)", initVal, resVal, p.timer.Elapsed())
 								delta := math.Abs(initVal - resVal)
 								if delta <= stddev {
 									if successful >= p.SuccessCount {
@@ -268,7 +269,6 @@ func (p *Poller) Wait(ctx context.Context, interval time.Duration, deadline time
 									successful++
 									continue
 								} else {
-									metricChan <- fmt.Sprintf("initial value %g, current value %g (%s elapsed)", initVal, resVal, p.timer.Elapsed())
 									successful = 0
 									continue
 								}

--- a/poller.go
+++ b/poller.go
@@ -175,7 +175,7 @@ func (p *Poller) Init(ctx context.Context) {
 	wg.Wait()
 }
 
-func (p *Poller) Wait(ctx context.Context, interval time.Duration, deadline time.Duration) (<-chan string, <-chan error) {
+func (p *Poller) Wait(ctx context.Context, interval time.Duration) (<-chan string, <-chan error) {
 	metricChan := make(chan string)
 	doneChan := make(chan error)
 	go func() {
@@ -239,11 +239,6 @@ func (p *Poller) Wait(ctx context.Context, interval time.Duration, deadline time
 						successful := 0
 
 						for {
-							if p.timer.Elapsed() > deadline {
-								waitErr <- fmt.Errorf("error: elapsed time exceeded deadline")
-								return
-							}
-
 							fmt.Printf("Waiting %s (%s elapsed) to poll for metrics\n", interval, p.timer.Elapsed())
 							<-time.After(interval)
 

--- a/poller.go
+++ b/poller.go
@@ -175,7 +175,7 @@ func (p *Poller) Init(ctx context.Context) {
 	wg.Wait()
 }
 
-func (p *Poller) Wait(ctx context.Context, interval time.Duration) <-chan error {
+func (p *Poller) Wait(ctx context.Context, interval time.Duration, deadline time.Duration) <-chan error {
 	doneChan := make(chan error)
 	go func() {
 		p.timer = monotime.New()
@@ -238,6 +238,11 @@ func (p *Poller) Wait(ctx context.Context, interval time.Duration) <-chan error 
 						successful := 0
 
 						for {
+							if p.timer.Elapsed() > deadline {
+								waitErr <- fmt.Errorf("error: elapsed time exceeded deadline")
+								return
+							}
+
 							fmt.Printf("Waiting %s (%s elapsed) to poll for metrics\n", interval, p.timer.Elapsed())
 							<-time.After(interval)
 


### PR DESCRIPTION
## What 
There are two changes in this PR: 
- Add a second channel for metric updates showing the initial value, current value, and elapsed time 
- Add a deadline in Wait method. Use the timeout argument for the deadline.  

## How 
While the metrics settle out, pass updates to metricChan. `%g` was used (floating point with exponent) because I was unsure what the scale of values would be. 

## Why 
- Return more information while the metrics settle. 
- Add more control for how long to wait for metrics to settle. 