### PR TITLE
Truncate Notify Values

### DIFF
--- a/poller.go
+++ b/poller.go
@@ -256,8 +256,9 @@ func (p *Poller) Wait(ctx context.Context, interval time.Duration, notifyMetrics
 								}
 
 								if notifyMetrics != nil {
-									fmt.Printf("initial value %g, current value %g (%s elapsed)", initVal, resVal, p.timer.Elapsed())
-									notifyMetrics(fmt.Sprintf("initial value %g, current value %g (%s elapsed)", initVal, resVal, p.timer.Elapsed()))
+									roundedElapsed := p.timer.Elapsed().Round(time.Millisecond)
+									notifyMetrics(fmt.Sprintf("initial value %.2f, current value %.2f (%s elapsed)", initVal, resVal, roundedElapsed))
+									fmt.Printf("initial value %.2f, current value %.2f (%s elapsed)", initVal, resVal, roundedElapsed)
 								}
 
 								delta := math.Abs(initVal - resVal)


### PR DESCRIPTION
## What 
Truncate the decimal places of the notify values. 

## How 
- `%g` -> `%.2f`: float type with two decimals shown
- `time.Elapsed()` -> `time.Elapsed().Round(time.Millisecond)`: round time to the millisecond 

## Why 
The number of decimal places included in the notify values is distracting. This change will clean up deploy builder notifications, specifically for its `Metrics settling...` notification.  